### PR TITLE
add pip check, types-urllib3 dep

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,15 @@
-{% set name = "types-requests" %}
 {% set version = "2.27.11" %}
 
-
 package:
-  name: {{ name|lower }}
+  name: types-requests
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-requests-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/t/types-requests/types-requests-{{ version }}.tar.gz
   sha256: 6a7ed24b21780af4a5b5e24c310b2cd885fb612df5fd95584d03d87e5f2a195a
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -21,11 +19,14 @@ requirements:
     - python >=3.6
   run:
     - python >=3.6
+    - types-urllib3 <1.27
 
 test:
+  requires:
+    - pip
   commands:
-    - test -f $SP_DIR/requests-stubs/__init__.pyi
-
+    - pip check
+    - test -f $SP_DIR/requests-stubs/__init__.pyi  # [unix]
 
 about:
   home: https://github.com/python/typeshed


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


Notes:
- adds dependency on `types-urllib3 <1.27`
  - noticed on https://github.com/conda-forge/ossindex-lib-feedstock/pull/1
    ```
    + pip check
    types-requests 2.27.11 requires types-urllib3, which is not installed.
    ```
- adds `pip check` to help catch changes in the future
- puts test behind `unix` flag (just 'cause)
- removes the name jinja variable, as seems to be the convention these days
- thanks!